### PR TITLE
fix missing shadow-box for white square view

### DIFF
--- a/css/gallery-owl-carousel.css
+++ b/css/gallery-owl-carousel.css
@@ -156,6 +156,7 @@ body .foogallery-owl-carousel.foogallery-lightbox-none.border-style-rounded .foo
     -moz-border-radius:  5px;
 }
 
+body .foogallery-owl-carousel.border-style-square-white a,
 body .foogallery-owl-carousel.foogallery-lightbox-none.border-style-square-white .foo-item  {
     border:  5px solid #FFF;
     -webkit-box-shadow:  0 0 10px rgba(0,  0,  0,  0.5);


### PR DESCRIPTION
added a missing css notation, line 159
refer to: https://wordpress.org/support/topic/missing-shadow-box-for-white-square-view/